### PR TITLE
Git hook auto-applies ssh url to remote origin if url is not ssh

### DIFF
--- a/Formula/democ.rb
+++ b/Formula/democ.rb
@@ -2,10 +2,11 @@
 # title   :democ
 # version :0.0.0
 # desc    :C cli built as part of the homebrew demo/dev tools project
-# usage   :See the repo README file for usage
-# exit    :0=success, 1=input error 2=execution error
 # auth    :Tate Hanawalt(tate@tatehanawalt.com)
 # date    :1621396284
+#==============================================================================
+# usage   :See the repo README file for usage
+# exit    :0=success, 1=input error 2=execution error
 #==============================================================================
 class Democ < Formula
   depends_on "gcc" => :install            # dependencies

--- a/Formula/democpp.rb
+++ b/Formula/democpp.rb
@@ -1,11 +1,12 @@
 #==============================================================================
 # title   :democpp
-# version :0.0.0
 # desc    :C++ cli built as part of the homebrew demo/dev tools project
-# usage   :See the repo README file for usage
-# exit    :0=success, 1=input error 2=execution error
-# auth    :Tate Hanawalt(tate@tatehanawalt.com)
+# version :0.0.0
 # date    :1621396284
+# auth    :Tate Hanawalt(tate@tatehanawalt.com)
+#==============================================================================
+# exit    :0=success, 1=input error 2=execution error
+# usage   :See the repo README file for usage
 #==============================================================================
 class Democpp < Formula
   depends_on "g++" => :install            # dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <br>
 
+# HOOK TEST:
+
 # <div align="center">TATE HANAWALT DEVTOOLS</div><br>
 
 ## <div align="center">Tools and Projects available through [BREW](https://brew.sh/)</div><br>


### PR DESCRIPTION
Added git hook script that executes post-commit to fix the remote origin URL if the URL is not an ssh URL. 

script located in `r/.ig/hooks`